### PR TITLE
Add error details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+Gopkg.lock
+vendor


### PR DESCRIPTION
Custom Errors can now have an optional `details` property that allows
for arbitrary details to be added to an error object. This attribute is
a slice and allows for appending more details to the same error object.