### PR TITLE
Implement Unwrap method

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -119,6 +119,9 @@ type causer interface {
 // Cause unwraps error
 func (c *customError) Cause() error { return c.error }
 
+// Unwrap error
+func (c *customError) Unwrap() error { return goerrors.Unwrap(c.error) }
+
 // typed interface identifies error with a type
 type typed interface {
 	Type() ErrorType

--- a/errors.go
+++ b/errors.go
@@ -120,7 +120,7 @@ type causer interface {
 func (c *customError) Cause() error { return c.error }
 
 // Unwrap error
-func (c *customError) Unwrap() error { return goerrors.Unwrap(c.error) }
+func (c *customError) Unwrap() error { return c.error }
 
 // typed interface identifies error with a type
 type typed interface {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package weberr
 
 import (
+	goerrors "errors"
 	"fmt"
 	"io"
 	"testing"
@@ -165,6 +166,20 @@ func TestGetDetails(t *testing.T) {
 		}
 	}
 
+}
+
+func TestThatErrorsCanUnwrapWithGoStandardErrors(t *testing.T) {
+	parent := UserWrapf(nil, "parent error")
+	child := UserWrapf(parent, "child error")
+	if !Is(child, parent) {
+		t.Errorf("Expected to unwrap parent: '%v' with child '%v'", parent, child)
+	}
+
+	parent = goerrors.New("parent error")
+	child = fmt.Errorf("child error: %w", parent)
+	if !Is(child, parent) {
+		t.Errorf("Expected to unwrap parent: '%v' with child '%v'", parent, child)
+	}
 }
 
 // Helper function to compare slices


### PR DESCRIPTION
This change adds interoperability so that the standard library errors package can also be used to Unwrap weberr errors as well.

Curious what you think of this change.