### PR TITLE
Add go.mod and go.sum for dependency pinning [Generated by gurnben's Agent]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/openshift-online/weberr
+
+go 1.25.9
+
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Summary

Pins dependency versions to ensure reproducible builds and enable dependency security scanning.

### Changes

- Initializes `go.mod` with module path `github.com/openshift-online/weberr`
- Generates `go.sum` with checksums for the single dependency (`github.com/pkg/errors`)
- Enables `go mod tidy` and `go mod verify` for reproducible builds

### Why pin dependencies?

Without `go.mod`, Go tooling cannot verify dependency integrity or ensure reproducible builds. Any consumer of this library may get different transitive dependencies depending on when they fetch it.

## AgentReady Score Impact

This PR is part of an organization-wide initiative to improve AI-assisted development readiness across `openshift-online`, measured by [AgentReady](https://github.com/ambient-code/agentready) (v2.31.2).

| Metric | Value |
|--------|-------|
| **Current score** | **16.4/100** (Needs Improvement) |
| **This PR** | **+10 points** |
| **Score after this PR** | **26/100** (Needs Improvement) |

### Attribute addressed

- Dependency Pinning for Reproducibility (+10) — Tier 1 (Essential)

Dependency pinning is a **Tier 1 attribute** (10% of total score) because reproducible builds are foundational to both human and AI-assisted development. When an AI coding assistant suggests a dependency update or generates code that imports a package, pinned versions ensure the suggestion is tested against the exact same dependency tree the project uses.

## Testing

- [ ] No functional code changes — dependency metadata only
- [ ] Existing tests continue to pass with pinned versions

---

> :robot_face: *This PR was generated by an AI agent* ([Claude](https://claude.ai)) as part of an organization-wide initiative to improve AI-assisted development readiness across `openshift-online`. The agent assessed all 32 public repositories using [AgentReady](https://github.com/ambient-code/agentready), identified improvement opportunities, generated the changes, and opened this PR. All commits are GPG-signed by [@gurnben](https://github.com/gurnben).
