### PR TITLE
Add one-command build/setup: Makefile + Quick Start [Generated by gurnben's Agent]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build test fmt vet clean
+
+build:
+	go build ./...
+
+test:
+	go test ./... -v
+
+fmt:
+	gofmt -w .
+
+vet:
+	go vet ./...
+
+clean:
+	go clean ./...

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Package weberr based on https://github.com/pkg/errors with a few additions:
 
 [Read the package documentation for more information](https://godoc.org/github.com/zgalor/weberr).
 
+## Quick Start
+
+```bash
+make build       # Build the package
+make test        # Run all tests
+```
+
 ## Divergences from pkg/errors
 
 * We chose `weberr.Wrapf(nil, ...)` and similar wrapping functions should return a new error, whereas `errors.Wrapf(nil, ...)` historically returns nil.


### PR DESCRIPTION
## Summary

Adds one-command build/setup capability to improve developer onboarding and AI-assisted development.

### Changes

- **Makefile** (new) — Go-appropriate build targets: `make build`, `make test`, `make fmt`, `make vet`, `make clean`
- **README.md** — added Quick Start section with `make` commands in a prominent position


### Why this matters

[AgentReady](https://github.com/ambient-code/agentready) checks for two things in the One-Command Build/Setup attribute:

1. A build automation tool exists (Makefile, setup script, etc.)
2. The setup command is documented **prominently in the README** (within the first few sections)

This PR addresses both requirements.

## AgentReady Score Impact

| Metric | Value |
|--------|-------|
| **Current score** | **19.1/100** (Needs Improvement) |
| **This PR** | **+3 points** |
| **Score after this PR** | **22/100** (Needs Improvement) |

### Attribute addressed

- One-Command Build/Setup (+3) — Tier 2 (Critical)

## Testing

- [ ] No functional code changes — Makefile and documentation only
- [ ] `make build` and `make test` work correctly

---

> :robot_face: *This PR was generated by an AI agent* ([Claude](https://claude.ai)) as part of an organization-wide initiative to improve AI-assisted development readiness across `openshift-online`. The agent assessed all 32 public repositories using [AgentReady](https://github.com/ambient-code/agentready), identified improvement opportunities, generated the changes, and opened this PR. All commits are GPG-signed by [@gurnben](https://github.com/gurnben).
